### PR TITLE
Fix typos

### DIFF
--- a/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Bindings/RNBOAudioUnit.h
+++ b/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Bindings/RNBOAudioUnit.h
@@ -22,7 +22,7 @@ extern void processBuffer(float *p, int len);
 //    AUAudioUnitBusArray *inputBusArray;
 }
 
-- (void)setParameterValue:(size_t)number valueNormalized:(float)v;
+- (void)setParameterValue:(size_t)number value:(float)v;
 - (void)setParameterValueNormalized:(size_t)number valueNormalized:(float)v;
 - (size_t)getParameterCount;
 

--- a/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Bindings/RNBOAudioUnit.mm
+++ b/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Bindings/RNBOAudioUnit.mm
@@ -439,9 +439,6 @@ std::string _getStringFrom(CFURLRef cfUrl) {
     }
 }
 
-- (void)setParameterValue:(size_t)number valueNormalized:(float)v {
-}
-
 @end
 
 // eof

--- a/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Interface/RNBOAudioEngine.swift
+++ b/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Interface/RNBOAudioEngine.swift
@@ -20,7 +20,7 @@ class RNBOAudioEngine {
         let format = avAudioUnit!.inputFormat(forBus: 0)
         
         if (format.channelCount > 0) {
-           engine.connect(engine.inputNode, to: avAudioUnit!, format: format)
+           engine.connect(input, to: avAudioUnit!, format: format)
         }
     }
     init() {
@@ -95,7 +95,7 @@ class RNBOAudioEngine {
         
         // engine.connect(playerNode, to: avAudioUnit!, format: audioFile?.processingFormat)
         let audioUnitFormat =  avAudioUnit!.inputFormat(forBus: 0)
-        let procFormat = audioFile?.processingFormat
+//        let procFormat = audioFile?.processingFormat
         engine.connect(playerNode, to: avAudioUnit!, format: audioUnitFormat)
         engine.connect(avAudioUnit!, to: engine.mainMixerNode, format: audioUnitFormat)
         

--- a/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Interface/RNBOAudioUnitHostModel.swift
+++ b/SwiftRNBO_Example_multiplatfrom_SwiftUI/SwiftRNBO_Example_multiplatfrom_SwiftUI/RNBO/Interface/RNBOAudioUnitHostModel.swift
@@ -26,7 +26,7 @@ class RNBOAudioUnitHostModel: ObservableObject {
     }
 
     func setParameterValue(to value: Double, at parameterIndex: Int) {
-        audioUnit.setParameterValue(parameterIndex, valueNormalized: Float(value))
+        audioUnit.setParameterValue(parameterIndex, value: Float(value))
         parameters[parameterIndex].value = Double(audioUnit.getParameterValue(parameterIndex))
     }
 


### PR DESCRIPTION
`valueNormalized:` was instead of `value` as an argument label in a function fixed;
removed unnecessary variables;